### PR TITLE
Add new environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 - yarn test
 - yarn lint
 - yarn test-gen
+- yarn test-gen-env
 - yarn check
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "lint": "eslint src",
     "build": "babel src -d lib --ignore '*.test.js'",
     "watch": "babel --watch src -d lib --ignore '*.test.js'",
-    "test-gen": "rm -rf ./tmp && npm run build && ./lib/index.js  https://demo.api-platform.com ./tmp"
+    "test-gen": "rm -rf ./tmp && npm run build && ./lib/index.js https://demo.api-platform.com ./tmp",
+    "test-gen-env": "rm -rf ./tmp && npm run build && API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT=https://demo.api-platform.com API_PLATFORM_CLIENT_GENERATOR_OUTPUT=./tmp ./lib/index.js"
   },
   "bin": {
     "generate-api-platform-client": "./lib/index.js"

--- a/src/index.js
+++ b/src/index.js
@@ -9,36 +9,39 @@ import generators from './generators';
 program
   .version(version)
   .description('Generate a CRUD application built with React, Redux and React Router from an Hydra-enabled API')
-  .usage('apiEntrypoint outputDirectory')
+  .usage('entrypoint outputDirectory')
   .option('-r, --resource [resourceName]', 'Generate CRUD for the given resource')
   .option('-p, --hydra-prefix [hydraPrefix]', 'The hydra prefix used by the API', 'hydra:')
   .option('-g, --generator [generator]', 'The generator to use, one of "react", "angular" etc.', 'react')
   .parse(process.argv);
 
-if (2 !== program.args.length) {
+if (2 !== program.args.length && (!process.env.API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT || !process.env.API_PLATFORM_CLIENT_GENERATOR_OUTPUT)) {
   program.help();
 }
 
-const generator = generators(program.generator)(program.hydraPrefix)
+const entrypoint = program.args[0] || process.env.API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT;
+const outputDirectory = program.args[1] || process.env.API_PLATFORM_CLIENT_GENERATOR_OUTPUT;
+
+const generator = generators(program.generator)(program.hydraPrefix);
 const resourceToGenerate = program.resource ? program.resource.toLowerCase() : null;
 
-parseHydraDocumentation(program.args[0]).then(api => {
+parseHydraDocumentation(entrypoint).then(api => {
   for (let resource of api.api.resources) {
     const nameLc = resource.name.toLowerCase();
     const titleLc = resource.title.toLowerCase();
 
     if (null === resourceToGenerate || nameLc === resourceToGenerate || titleLc === resourceToGenerate) {
-      generator.generate(api, resource, program.args[1]);
+      generator.generate(api, resource, outputDirectory);
       generator.help(resource)
     }
   }
 
   if ('entrypoint' in generator) {
-    generator.entrypoint(program.args[0], program.args[1]);
+    generator.entrypoint(entrypoint, outputDirectory);
   }
 
   if ('utils' in generator) {
-    generator.utils(program.args[1]);
+    generator.utils(outputDirectory);
   }
 }).catch((e) => {
   console.log(e);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

Add support for two new environment variables to configure the API entrypoint and the output directory: `API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT` and `API_PLATFORM_CLIENT_GENERATOR_OUTPUT`.

This is necessary for the new API Platform distribution I'm working on.