### PR TITLE
[react] Refactor fetch generation

### DIFF
--- a/src/generators/ReactGenerator.js
+++ b/src/generators/ReactGenerator.js
@@ -13,8 +13,8 @@ export default class extends BaseGenerator {
       'actions/foo/update.js',
       'actions/foo/show.js',
 
-      // api
-     'api/fooFetch.js',
+      // utils
+     'utils/fetch.js',
 
       // reducers
       'reducers/foo/create.js',
@@ -74,12 +74,12 @@ combineReducers(${titleLc},{/* ... */}),
       fields: resource.readableFields,
       formFields: this.buildFields(resource.writableFields),
       hydraPrefix: this.hydraPrefix,
-      titleUcFirst
+      titleUcFirst,
     };
 
     // Create directories
     // These directories may already exist
-    for (let dir of [`${dir}/api`, `${dir}/routes`, `${dir}/utils`]) {
+    for (let dir of [`${dir}/utils`, `${dir}/config`, `${dir}/routes`]) {
       this.createDir(dir, false);
     }
 
@@ -94,9 +94,6 @@ combineReducers(${titleLc},{/* ... */}),
       'actions/%s/list.js',
       'actions/%s/update.js',
       'actions/%s/show.js',
-
-      // api
-      'api/%sFetch.js',
 
       // components
       'components/%s/Create.js',
@@ -120,7 +117,11 @@ combineReducers(${titleLc},{/* ... */}),
       this.createFileFromPattern(pattern, dir, lc, context)
     }
 
-    this.createFile('utils/helpers.js', `${dir}/utils/helpers.js`, {}, false);
-    this.createEntrypoint(api.entrypoint, `${dir}/api/_entrypoint.js`)
+    // utils
+    for (let file of ['utils/helpers.js', 'utils/fetch.js']) {
+      this.createFile(file, `${dir}/${file}`, {}, false);
+    }
+
+    this.createEntrypoint(api.entrypoint, `${dir}/config/_entrypoint.js`)
   }
 }

--- a/src/generators/ReactGenerator.test.js
+++ b/src/generators/ReactGenerator.test.js
@@ -30,12 +30,15 @@ test('Generate a React app', () => {
   });
   generator.generate(api, resource, tmpobj.name);
 
+  expect(fs.existsSync(tmpobj.name+'/utils/fetch.js'), true);
+  expect(fs.existsSync(tmpobj.name+'/utils/helpers.js'), true);
+
+  expect(fs.existsSync(tmpobj.name+'/config/_entrypoint.js'), true);
+
   expect(fs.existsSync(tmpobj.name+'/actions/abc/create.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/delete.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/list.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/update.js'), true);
-
-  expect(fs.existsSync(tmpobj.name+'/api/abcFetch.js'), true);
 
   expect(fs.existsSync(tmpobj.name+'/components/abc/Create.js'), true);
   expect(fs.existsSync(tmpobj.name+'/components/abc/Form.js'), true);

--- a/src/generators/ReactNativeGenerator.js
+++ b/src/generators/ReactNativeGenerator.js
@@ -13,8 +13,8 @@ export default class extends BaseGenerator {
       'actions/foo/update.js',
       'actions/foo/show.js',
 
-      // api
-      'api/fooFetch.js',
+      // utils
+      'utils/fetch.js',
 
       // reducers
       'reducers/foo/create.js',
@@ -65,10 +65,11 @@ combineReducers(${titleLc},{/* ... */}),
       titleUcFirst
     };
 
-
     // Create directories
-    // This directories may already exist
-    this.createDir(`${dir}/api`, false);
+    // These directories may already exist
+    for (let dir of [`${dir}/utils`, `${dir}/config`]) {
+      this.createDir(dir, false);
+    }
 
     for (let dir of [`${dir}/actions/${lc}`, `${dir}/components/${lc}`, `${dir}/reducers/${lc}`]) {
       this.createDir(dir);
@@ -81,9 +82,6 @@ combineReducers(${titleLc},{/* ... */}),
       'actions/%s/list.js',
       'actions/%s/update.js',
       'actions/%s/show.js',
-
-      // api
-      'api/fooFetch.js',
 
       // components
       'components/%s/Create.js',
@@ -104,6 +102,7 @@ combineReducers(${titleLc},{/* ... */}),
       this.createFileFromPattern(pattern, dir, lc, context);
     }
 
-    this.createEntrypoint(api.entrypoint, `${dir}/api/_entrypoint.js`)
+    this.createFile('utils/fetch.js', `${dir}/utils/fetch.js`, {}, false);
+    this.createEntrypoint(api.entrypoint, `${dir}/config/_entrypoint.js`)
   }
 }

--- a/src/generators/ReactNativeGenerator.test.js
+++ b/src/generators/ReactNativeGenerator.test.js
@@ -30,12 +30,14 @@ test('Generate a React app', () => {
   });
   generator.generate(api, resource, tmpobj.name);
 
+  expect(fs.existsSync(tmpobj.name+'/utils/fetch.js'), true);
+
+  expect(fs.existsSync(tmpobj.name+'/config/_entrypoint.js'), true);
+
   expect(fs.existsSync(tmpobj.name+'/actions/abc/create.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/delete.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/list.js'), true);
   expect(fs.existsSync(tmpobj.name+'/actions/abc/update.js'), true);
-
-  expect(fs.existsSync(tmpobj.name+'/api/abcFetch.js'), true);
 
   expect(fs.existsSync(tmpobj.name+'/components/abc/Create.js'), true);
   expect(fs.existsSync(tmpobj.name+'/components/abc/Form.js'), true);

--- a/templates/react-common/actions/foo/create.js
+++ b/templates/react-common/actions/foo/create.js
@@ -1,5 +1,5 @@
 import { SubmissionError } from 'redux-form';
-import {{{ lc }}}Fetch from '../../api/{{{ lc }}}Fetch';
+import fetch from '../../utils/fetch';
 
 export function error(error) {
   return {type: '{{{ uc }}}_CREATE_ERROR', error};
@@ -17,7 +17,7 @@ export function create(values) {
   return (dispatch) => {
     dispatch(loading(true));
 
-    return {{{ lc }}}Fetch('/{{{ name }}}', {method: 'POST', body: JSON.stringify(values)})
+    return fetch('/{{{ name }}}', {method: 'POST', body: JSON.stringify(values)})
       .then(response => {
         dispatch(loading(false));
 

--- a/templates/react-common/actions/foo/delete.js
+++ b/templates/react-common/actions/foo/delete.js
@@ -1,4 +1,4 @@
-import {{{ lc }}}Fetch from '../../api/{{{ lc }}}Fetch';
+import fetch from '../../utils/fetch';
 
 export function error(error) {
   return {type: '{{{ uc }}}_DELETE_ERROR', error};
@@ -16,7 +16,7 @@ export function del(item) {
   return (dispatch) => {
     dispatch(loading(true));
 
-    return {{{ lc }}}Fetch(item['@id'], {method: 'DELETE'})
+    return fetch(item['@id'], {method: 'DELETE'})
       .then(() => {
         dispatch(loading(false));
         dispatch(success(item))

--- a/templates/react-common/actions/foo/list.js
+++ b/templates/react-common/actions/foo/list.js
@@ -1,4 +1,4 @@
-import {{{ lc }}}Fetch from '../../api/{{{ lc }}}Fetch';
+import fetch from '../../utils/fetch';
 
 export function error(error) {
   return {type: '{{{ uc }}}_LIST_ERROR', error};
@@ -21,7 +21,7 @@ export function page(page) {
     dispatch(loading(true));
     dispatch(error(''));
 
-    {{{ lc }}}Fetch(page)
+    fetch(page)
       .then(response => response.json())
       .then(data => {
         dispatch(loading(false));

--- a/templates/react-common/actions/foo/show.js
+++ b/templates/react-common/actions/foo/show.js
@@ -1,4 +1,4 @@
-import {{{ lc }}}Fetch from '../../api/{{{ lc }}}Fetch';
+import fetch from '../../utils/fetch';
 
 export function error(error) {
   return {type: '{{{ uc }}}_SHOW_ERROR', error};
@@ -16,7 +16,7 @@ export function retrieve(id) {
   return (dispatch) => {
     dispatch(loading(true));
 
-    return {{{ lc }}}Fetch(id)
+    return fetch(id)
       .then(response => response.json())
       .then(data => {
         dispatch(loading(false));

--- a/templates/react-common/actions/foo/update.js
+++ b/templates/react-common/actions/foo/update.js
@@ -1,5 +1,5 @@
 import { SubmissionError } from 'redux-form';
-import {{{ lc }}}Fetch from '../../api/{{{ lc }}}Fetch';
+import fetch from '../../utils/fetch';
 import { success as createSuccess } from './create';
 
 export function retrieveError(retrieveError) {
@@ -18,7 +18,7 @@ export function retrieve(id) {
   return (dispatch) => {
     dispatch(retrieveLoading(true));
 
-    return {{{ lc }}}Fetch(id)
+    return fetch(id)
       .then(response => response.json())
       .then(data => {
         dispatch(retrieveLoading(false));
@@ -49,7 +49,7 @@ export function update(item, values) {
     dispatch(createSuccess(null));
     dispatch(updateLoading(true));
 
-    return {{{ lc }}}Fetch(item['@id'], {
+    return fetch(item['@id'], {
         method: 'PUT',
         headers: new Headers({'Content-Type': 'application/ld+json'}),
         body: JSON.stringify(values),

--- a/templates/react-common/utils/fetch.js
+++ b/templates/react-common/utils/fetch.js
@@ -3,7 +3,7 @@ import { API_HOST, API_PATH } from './_entrypoint';
 
 const jsonLdMimeType = 'application/ld+json';
 
-export default function {{{ lc }}}Fetch(url, options = {}) {
+export default function fetch(url, options = {}) {
   if ('undefined' === typeof options.headers) options.headers = new Headers();
   if (null === options.headers.get('Accept')) options.headers.set('Accept', jsonLdMimeType);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

* Generate only one `fetch` file per project and move it under the `utils/` directory
* Move `_entrypoint.js` in `config/` (as done in the VueJS generator)