### PR TITLE
Fix entrypoint generation

### DIFF
--- a/src/generators/BaseGenerator.js
+++ b/src/generators/BaseGenerator.js
@@ -46,10 +46,9 @@ export default class {
 
   createEntrypoint(apiEntry, dest) {
     const url = urlapi.parse(apiEntry);
-    const {protocol, host, port, pathname} = url;
-    const hostUrl = `${protocol}//${host}${port ? `:${port}` : ''}`;
+    const {protocol, host, pathname} = url;
 
-    this.createFile('_entrypoint.js', dest, {host: hostUrl, path: pathname}, false);
+    this.createFile('_entrypoint.js', dest, {host: `${protocol}//${host}`, path: pathname}, false);
   }
 
   getHtmlInputTypeFromField(field) {

--- a/templates/_entrypoint.js
+++ b/templates/_entrypoint.js
@@ -1,2 +1,2 @@
-export const API_HOST = "{{{host}}}";
-export const API_PATH = "{{{path}}}";
+export const API_HOST = '{{{host}}}';
+export const API_PATH = '{{{path}}}';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If the URL contains a port, it was duplicated in `_entrypoint.js` because `host` already contains the port (`hostname` doesn't).

This PR fixes this bug.