### PR TITLE
Improve the pagination system

### DIFF
--- a/templates/react-common/actions/foo/list.js
+++ b/templates/react-common/actions/foo/list.js
@@ -8,15 +8,11 @@ export function loading(loading) {
   return {type: '{{{ uc }}}_LIST_LOADING', loading};
 }
 
-export function success(items) {
-  return {type: '{{{ uc }}}_LIST_SUCCESS', items};
+export function success(data) {
+  return {type: '{{{ uc }}}_LIST_SUCCESS', data};
 }
 
-export function view(items) {
-  return { type: '{{{ uc }}}_LIST_VIEW', items};
-}
-
-export function page(page) {
+export function list(page = '/{{{ name }}}') {
   return (dispatch) => {
     dispatch(loading(true));
     dispatch(error(''));
@@ -25,18 +21,13 @@ export function page(page) {
       .then(response => response.json())
       .then(data => {
         dispatch(loading(false));
-        dispatch(success(data['{{{ hydraPrefix }}}member']));
-        dispatch(view(data['{{{ hydraPrefix }}}view']));
+        dispatch(success(data));
       })
       .catch(e => {
         dispatch(loading(false));
         dispatch(error(e.message))
       });
   };
-}
-
-export function list() {
-  return page('/{{{ name }}}');
 }
 
 export function reset() {

--- a/templates/react-common/reducers/foo/list.js
+++ b/templates/react-common/reducers/foo/list.js
@@ -26,27 +26,17 @@ export function loading(state = false, action) {
   }
 }
 
-export function items(state = [], action) {
+export function data(state = {}, action) {
   switch (action.type) {
     case '{{{ uc }}}_LIST_SUCCESS':
-      return action.items;
+      return action.data;
 
     case '{{{ uc }}}_LIST_RESET':
-      return [];
+      return {};
 
     default:
       return state;
   }
 }
 
-export function view(state = [], action) {
-  switch (action.type) {
-    case '{{{ uc }}}_LIST_VIEW':
-      return action.items;
-
-    default:
-      return state;
-  }
-}
-
-export default combineReducers({error, loading, items, view});
+export default combineReducers({error, loading, data});

--- a/templates/react/components/foo/List.js
+++ b/templates/react/components/foo/List.js
@@ -36,6 +36,8 @@ class List extends Component {
       {this.props.deletedItem && <div className="alert alert-success">{this.props.deletedItem['@id']} deleted.</div>}
       {this.props.error && <div className="alert alert-danger">{this.props.error}</div>}
 
+      <p><Link to="create" className="btn btn-default">Create</Link></p>
+
       <div className="table-responsive">
           <table className="table table-striped table-hover">
           <thead>
@@ -73,8 +75,6 @@ class List extends Component {
         </table>
       </div>
 
-      <Link to="create" className="btn btn-default">Create</Link>
-
       {this.pagination()}
     </div>;
   }
@@ -83,13 +83,13 @@ class List extends Component {
     const view = this.props.data['hydra:view'];
     if (!view) return;
 
-    const {'{{{ hydraPrefix }}}first': first, '{{{ hydraPrefix }}}previous': previous,'{{{ hydraPrefix }}}next': next} = view;
+    const {'{{{ hydraPrefix }}}first': first, '{{{ hydraPrefix }}}previous': previous,'{{{ hydraPrefix }}}next': next, '{{{ hydraPrefix }}}last': last} = view;
 
     return <nav aria-label="Page navigation">
-      <ul className="pager">
-        <li className={`previous${previous ? '' : ' disabled'}`}><Link to={previous === first ? '.' : encodeURIComponent(previous)}><span aria-hidden="true">&larr;</span> Previous</Link></li>
-        <li className={`next${next ? '' : ' disabled'}`}><Link to={encodeURIComponent(next)}>Next <span aria-hidden="true">&rarr;</span></Link></li>
-      </ul>
+        <Link to='.' className={`btn btn-default${previous ? '' : ' disabled'}`}><span aria-hidden="true">&lArr;</span> First</Link>
+        <Link to={!previous || previous === first ? '.' : encodeURIComponent(previous)} className={`btn btn-default${previous ? '' : ' disabled'}`}><span aria-hidden="true">&larr;</span> Previous</Link>
+        <Link to={next ? encodeURIComponent(next) : '#'} className={`btn btn-default${next ? '' : ' disabled'}`}>Next <span aria-hidden="true">&rarr;</span></Link>
+        <Link to={last ? encodeURIComponent(last) : '#'} className={`btn btn-default${next ? '' : ' disabled'}`}>Last <span aria-hidden="true">&rArr;</span></Link>
     </nav>;
   }
 }

--- a/templates/react/routes/foo.js
+++ b/templates/react/routes/foo.js
@@ -1,18 +1,10 @@
 import React from 'react';
 import {Route} from 'react-router-dom';
+import {List,Create, Update, Show} from '../components/{{{lc}}}/';
 
-import {
-  List as {{{titleUcFirst}}}List,
-  Create as {{{titleUcFirst}}}Create,
-  Update as {{{titleUcFirst}}}Update,
-  Show as {{{titleUcFirst}}}Show
-} from '../components/{{{lc}}}/';
-
-export default (
-  [
-    <Route path='/{{{name}}}/' component={ {{{titleUcFirst}}}List } exact={true} strict={true} key='{{{titleUcFirst}}}List'/>,
-    <Route path='/{{{name}}}/create' component={ {{{titleUcFirst}}}Create } exact={true} key='{{{titleUcFirst}}}Create'/>,
-    <Route path="/{{{name}}}/edit/:id" component={ {{{titleUcFirst}}}Update } exact={true} key='{{{titleUcFirst}}}Update'/>,
-    <Route path="/{{{name}}}/show/:id" component={ {{{titleUcFirst}}}Show } exact={true} key='{{{titleUcFirst}}}Show'/>
-  ]
-);
+export default [
+  <Route path='/{{{name}}}/create' component={Create} exact={true} key='create'/>,
+  <Route path='/{{{name}}}/edit/:id' component={Update} exact={true} key='update'/>,
+  <Route path='/{{{name}}}/show/:id' component={Show} exact={true} key='show'/>,
+  <Route path='/{{{name}}}/:page?' component={List} strict={true} key='list'/>,
+];

--- a/templates/react/utils/helpers.js
+++ b/templates/react/utils/helpers.js
@@ -17,7 +17,3 @@ function createLink(item) {
 
   return <span><Link key={item} to={`/${route}/show/${encodeURIComponent(item)}`}>{item}</Link><br/></span>;
 }
-
-export function paginationRoute(item) {
-  return '/' + item.split('/').splice(-1, 1);
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

![capture d ecran 2017-10-06 a 12 20 29](https://user-images.githubusercontent.com/57224/31274114-d77fb65e-aa91-11e7-8e3d-a5a9498281b8.png)

* Rely on React Router (the URL change when going to another page)
* Use the Bootstrap `pagination` component
* Clean the code (the `list`, `page` and `view` reducers have been merged)
* Fix the following error `Given action "GREETING_LIST_VIEW", reducer "view" returned undefined. To ignore an action, you must explicitly return the previous state. If you want this reducer to hold no value, you can return null instead of undefined.` (it was a bug in the `view` reducer, that has been removed in this PR)
* Don't crash when filters are added
* Support new paginators (partial, offset) introduced by @meyerbaptiste

There is just a tiny problem, I can't find a way to prevent the url `/greetings` (without trailing slash) to work (I want this URL to return a 404). If the page is loaded without the trailing slash, links are broken. If you have an idea of how to block this URL, let me know.