### PR TITLE
Add option to use swagger documentation as resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://badge.fury.io/js/%40api-platform%2Fclient-generator.svg)](https://badge.fury.io/js/%40api-platform%2Fclient-generator)
 [![MIT Licence](https://badges.frapsoft.com/os/mit/mit.svg?v=103)](https://opensource.org/licenses/mit-license.php)
 
-API Platform Client Generator is a generator to scaffold app with Create-Retrieve-Update-Delete features for any API exposing a Hydra documentation for:
+API Platform Client Generator is a generator to scaffold app with Create-Retrieve-Update-Delete features for any API exposing a Hydra or Swagger documentation for:
  * React/Redux
  * Vue.js
 
@@ -16,7 +16,15 @@ Works especially well with APIs built with the [API Platform](https://api-platfo
 
 ## Usage
 
-    generate-api-platform-client https://demo.api-platform.com/ output/ --resource Book
+**Hydra**
+```sh
+generate-api-platform-client https://demo.api-platform.com/ output/ --resource Book
+```
+
+**Swagger**
+```sh
+generate-api-platform-client https://demo.api-platform.com/ output/ --resource Book --format swagger
+```
 
 ## Features
 
@@ -25,7 +33,7 @@ Works especially well with APIs built with the [API Platform](https://api-platfo
   * A creation form
   * An edition form
   * A deletion button
-* Use the Hydra API documentation to generate the code
+* Use the Hydra or Swagger API documentation to generate the code
 * Generate the suitable HTML5 input type (`number`, `date`...) according to the type of the API property
 * Display of the server-side validation errors under the related input (if using API Platform Core)
 * Client-side validation (`required` attributes)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tmp": "^0.0.31"
   },
   "dependencies": {
-    "@api-platform/api-doc-parser": "^0.4",
+    "@api-platform/api-doc-parser": "^0.5.0",
     "babel-runtime": "^6.23.0",
     "chalk": "^2.1.0",
     "commander": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "build": "babel src -d lib --ignore '*.test.js'",
     "watch": "babel --watch src -d lib --ignore '*.test.js'",
     "test-gen": "rm -rf ./tmp && npm run build && ./lib/index.js  https://demo.api-platform.com ./tmp/react && ./lib/index.js https://demo.api-platform.com ./tmp/react-native -g react-native && ./lib/index.js https://demo.api-platform.com ./tmp/vue -g vue && ./lib/index.js https://demo.api-platform.com ./tmp/admin-on-rest -g admin-on-rest",
+    "test-gen-swagger": "rm -rf ./tmp && npm run build && ./lib/index.js  https://demo.api-platform.com/docs.json ./tmp/react -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/react-native -g react-native -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/vue -g vue -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/admin-on-rest -g admin-on-rest -f swagger",
     "test-gen-env": "rm -rf ./tmp && npm run build && API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT=https://demo.api-platform.com API_PLATFORM_CLIENT_GENERATOR_OUTPUT=./tmp ./lib/index.js"
   },
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import 'isomorphic-fetch';
 import program from 'commander';
 import parseHydraDocumentation from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
+import parseSwaggerDocumentation from '@api-platform/api-doc-parser/lib/swagger/parseSwaggerDocumentation';
 import {version} from '../package.json';
 import generators from './generators';
 
@@ -14,6 +15,7 @@ program
   .option('-p, --hydra-prefix [hydraPrefix]', 'The hydra prefix used by the API', 'hydra:')
   .option('-g, --generator [generator]', 'The generator to use, one of "react", "react-native", "vue", "admin-on-rest"', 'react')
   .option('-t, --template-directory [templateDirectory]', 'The templates directory base to use. Final directory will be ${templateDirectory}/${generator}', `${__dirname}/../templates/`)
+  .option('-s, --resource-type [resourceType]', 'Hydra or Swagger', 'hydra')
   .parse(process.argv);
 
 if (2 !== program.args.length && (!process.env.API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT || !process.env.API_PLATFORM_CLIENT_GENERATOR_OUTPUT)) {
@@ -29,7 +31,14 @@ const generator = generators(program.generator)({
 });
 const resourceToGenerate = program.resource ? program.resource.toLowerCase() : null;
 
-parseHydraDocumentation(entrypoint).then(ret => {
+const parser = entrypoint => {
+  if (program.resourceType && program.resourceType === 'swagger') {
+    return parseSwaggerDocumentation(entrypoint)
+  }
+  return parseHydraDocumentation(entrypoint)
+}
+
+parser(entrypoint).then(ret => {
   for (let resource of ret.api.resources) {
     const nameLc = resource.name.toLowerCase();
     const titleLc = resource.title.toLowerCase();

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ program
   .option('-p, --hydra-prefix [hydraPrefix]', 'The hydra prefix used by the API', 'hydra:')
   .option('-g, --generator [generator]', 'The generator to use, one of "react", "react-native", "vue", "admin-on-rest"', 'react')
   .option('-t, --template-directory [templateDirectory]', 'The templates directory base to use. Final directory will be ${templateDirectory}/${generator}', `${__dirname}/../templates/`)
-  .option('-s, --resource-type [resourceType]', 'Hydra or Swagger', 'hydra')
+  .option('-f, --format [hydra|swagger]', '"hydra" or "swagger', 'hydra')
   .parse(process.argv);
 
 if (2 !== program.args.length && (!process.env.API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT || !process.env.API_PLATFORM_CLIENT_GENERATOR_OUTPUT)) {
@@ -32,10 +32,9 @@ const generator = generators(program.generator)({
 const resourceToGenerate = program.resource ? program.resource.toLowerCase() : null;
 
 const parser = entrypoint => {
-  if (program.resourceType && program.resourceType === 'swagger') {
-    return parseSwaggerDocumentation(entrypoint)
-  }
-  return parseHydraDocumentation(entrypoint)
+  const parseDocumentation = 'swagger' === program.format ? parseSwaggerDocumentation : parseHydraDocumentation;
+
+  return parseDocumentation(entrypoint)
 }
 
 parser(entrypoint).then(ret => {

--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,7 @@ program
     "The templates directory base to use. Final directory will be ${templateDirectory}/${generator}",
     `${__dirname}/../templates/`
   )
-  .option(
-    "-f, --format [hydra|swagger]", 
-    '"hydra" or "swagger', 
-    "hydra"
-  )
+  .option("-f, --format [hydra|swagger]", '"hydra" or "swagger', "hydra")
   .parse(process.argv);
 
 if (
@@ -61,12 +57,13 @@ const resourceToGenerate = program.resource
   : null;
 
 const parser = entrypoint => {
-  const parseDocumentation = 'swagger' === program.format 
-    ? parseSwaggerDocumentation 
-    : parseHydraDocumentation;
+  const parseDocumentation =
+    "swagger" === program.format
+      ? parseSwaggerDocumentation
+      : parseHydraDocumentation;
 
-  return parseDocumentation(entrypoint)
-}
+  return parseDocumentation(entrypoint);
+};
 
 parser(entrypoint)
   .then(ret => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@api-platform/api-doc-parser@^0.4":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@api-platform/api-doc-parser/-/api-doc-parser-0.4.0.tgz#92f24a445aaa2a8fac78e3a2069a78414854e9bb"
+"@api-platform/api-doc-parser@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@api-platform/api-doc-parser/-/api-doc-parser-0.5.0.tgz#c8d2d860937d5c795577dec33f7914567f5ec9eb"
   dependencies:
     babel-runtime "^6.23.0"
     jsonld "^0.4.11"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

The work still in progress, but I'm open this Pull Request just to let you guys know how it is going.

I'm open a PR to [api-doc-parser](https://github.com/api-platform/api-doc-parser/pull/30) as well, including this feature.
