### PR TITLE
Allow to send empty relation lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "build": "babel src -d lib --ignore '*.test.js'",
     "watch": "babel --watch src -d lib --ignore '*.test.js'",
-    "test-gen": "rm -rf ./tmp && npm run build && ./lib/index.js  https://demo.api-platform.com ./tmp/react && ./lib/index.js https://demo.api-platform.com ./tmp/react-native -g react-native && ./lib/index.js https://demo.api-platform.com ./tmp/vue -g vue && ./lib/index.js https://demo.api-platform.com ./tmp/admin-on-rest -g admin-on-rest",
+    "test-gen": "rm -rf ./tmp && yarn build && ./lib/index.js https://demo.api-platform.com ./tmp/react && ./lib/index.js https://demo.api-platform.com ./tmp/react-native -g react-native && ./lib/index.js https://demo.api-platform.com ./tmp/vue -g vue && ./lib/index.js https://demo.api-platform.com ./tmp/admin-on-rest -g admin-on-rest",
     "test-gen-cs": "./node_modules/.bin/prettier --single-quote -l \"./tmp/react/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
-    "test-gen-swagger": "rm -rf ./tmp && npm run build && ./lib/index.js  https://demo.api-platform.com/docs.json ./tmp/react -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/react-native -g react-native -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/vue -g vue -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/admin-on-rest -g admin-on-rest -f swagger",
-    "test-gen-env": "rm -rf ./tmp && npm run build && API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT=https://demo.api-platform.com API_PLATFORM_CLIENT_GENERATOR_OUTPUT=./tmp ./lib/index.js"
+    "test-gen-swagger": "rm -rf ./tmp && yarn build && ./lib/index.js  https://demo.api-platform.com/docs.json ./tmp/react -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/react-native -g react-native -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/vue -g vue -f swagger && ./lib/index.js https://demo.api-platform.com/docs.json ./tmp/admin-on-rest -g admin-on-rest -f swagger",
+    "test-gen-env": "rm -rf ./tmp && yarn build && API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT=https://demo.api-platform.com API_PLATFORM_CLIENT_GENERATOR_OUTPUT=./tmp ./lib/index.js"
   },
   "bin": {
     "generate-api-platform-client": "./lib/index.js"

--- a/templates/react/components/foo/Form.js
+++ b/templates/react/components/foo/Form.js
@@ -53,7 +53,7 @@ class Form extends Component {
           step="{{{step}}}"{{/if}}
           placeholder="{{{description}}}"{{#if required}}
           required={true}{{/if}}{{#if reference}}{{#unless maxCardinality}}
-          normalize={v => v.split(',')}{{/unless}}{{/if}}
+          normalize={v => v === '' ? [] : v.split(',')}{{/unless}}{{/if}}
         />
 {{/each}}
 

--- a/templates/react/components/foo/Form.js
+++ b/templates/react/components/foo/Form.js
@@ -53,7 +53,7 @@ class Form extends Component {
           step="{{{step}}}"{{/if}}
           placeholder="{{{description}}}"{{#if required}}
           required={true}{{/if}}{{#if reference}}{{#unless maxCardinality}}
-          normalize={v => v === '' ? [] : v.split(',')}{{/unless}}{{/if}}
+          normalize={v => (v === '' ? [] : v.split(','))}{{/unless}}{{/if}}
         />
 {{/each}}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This patch fixes a bug occuring when sending empty relations: the JSON was containing `[""]` instead of `[]`.