### PR TITLE
Fix numbers normalization

### DIFF
--- a/src/generators/BaseGenerator.js
+++ b/src/generators/BaseGenerator.js
@@ -66,10 +66,10 @@ export default class {
 
     switch (field.range) {
       case "http://www.w3.org/2001/XMLSchema#integer":
-        return { type: "number" };
+        return { type: "number", number: true };
 
       case "http://www.w3.org/2001/XMLSchema#decimal":
-        return { type: "number", step: "0.1" };
+        return { type: "number", step: "0.1", number: true };
 
       case "http://www.w3.org/2001/XMLSchema#boolean":
         return { type: "checkbox" };

--- a/templates/react/components/foo/Form.js
+++ b/templates/react/components/foo/Form.js
@@ -53,7 +53,8 @@ class Form extends Component {
           step="{{{step}}}"{{/if}}
           placeholder="{{{description}}}"{{#if required}}
           required={true}{{/if}}{{#if reference}}{{#unless maxCardinality}}
-          normalize={v => (v === '' ? [] : v.split(','))}{{/unless}}{{/if}}
+          normalize={v => (v === '' ? [] : v.split(','))}{{/unless}}{{/if}}{{#if number}}
+          normalize={v => parseFloat(v)}{{/if}}
         />
 {{/each}}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Currently, numbers are not normalized. Consequently they are sent as strings to the API, and rejected. This patch corrects this behavior.