### PR TITLE
Vue: made URL building path-sensitive

### DIFF
--- a/templates/vue/utils/fetch.js
+++ b/templates/vue/utils/fetch.js
@@ -3,6 +3,20 @@ import { ENTRYPOINT } from '../config/entrypoint';
 
 const MIME_TYPE = 'application/ld+json'
 
+function buildURL(entrypoint, id) {
+  entrypoint = entrypoint.replace(/\/+$/, '');
+
+  let splittedEntrypointPath = new URL(entrypoint).pathname.replace(/^\/+/, '').split('/');
+  let splittedId = id.replace(/^\/+/, '').split('/');
+
+  while (splittedEntrypointPath[0] === splittedId[0]) {
+    splittedEntrypointPath = splittedEntrypointPath.slice(1);
+    splittedId = splittedId.slice(1);
+  }
+
+  return `${entrypoint}/${splittedId.join('/')}`;
+}
+
 export default function (id, options = {}) {
   if (typeof options.headers === 'undefined') Object.assign(options, { headers: new Headers() })
 
@@ -12,7 +26,7 @@ export default function (id, options = {}) {
     options.headers.set('Content-Type', MIME_TYPE)
   }
 
-  return fetch(new URL(id, ENTRYPOINT).toString(), options).then((response) => {
+  return fetch(buildURL(ENTRYPOINT, id), options).then((response) => {
     if (response.ok) return response
 
     return response


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When generating a Vue.js client app for an API instance living under a non-empty path, e.g.:

```
generate-api-platform-client -g vue http://localhost:8000/api
```

Some of the generated store modules (e.g. `show`) call the provided `fetch` utility function as follows:

```js
fetch('/api/books/1') // resource id
```

...which, with `http://localhost:8000/api` as the entrypoint, **successfully** results in `http://localhost:8000/api/books/1`.

However, some other generated store modules (e.g. `list`) call it as follows:

```js
fetch('books') // generic resource name
```

...which, with `http://localhost:8000/api` as the entrypoint, **errouneously** results in `http://localhost:8000/books`.

This contribution brings in some userland code to correctly build these URLs in every case, **especially regarding path segment deduping** in situations such as the aforementioned one.

I did not provide unit tests as there aren't any for the generated code (which makes sense) but I wrote some locally to test-drive this implementation's development, so feel free to ask for them if you can tell me where to put them.