### PR TITLE
Fix the entrypoint missing the path prefix

### DIFF
--- a/templates/vue/utils/fetch.js
+++ b/templates/vue/utils/fetch.js
@@ -12,7 +12,9 @@ export default function (id, options = {}) {
     options.headers.set('Content-Type', MIME_TYPE)
   }
 
-  return fetch(new URL(id, ENTRYPOINT).toString(), options).then((response) => {
+  const entryPoint = ENTRYPOINT + (ENTRYPOINT.endsWith('/') ? '' : '/')
+
+  return fetch(new URL(id, entryPoint), options).then((response) => {
     if (response.ok) return response
 
     return response


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | _none_
| License       | MIT
| Doc PR        | _none_

When you create an app with your API endpoints on a subpath, for instance, `http://yoursite.tld/api`, the `/api` part of the URL was lost because of a behaviour of the JS `URL` prototype.
This PR solves that. Basically, it checks if the ENTRYPOINT has a trailing slash. If it doesn’t, the trailing slash is added, so the path is well appended to the URL.

Plus, we now use the `URL.href` property instead of the `toString()` function.