### PR TITLE
Add imports to typescript generator

### DIFF
--- a/src/generators/TypescriptInterfaceGenerator.test.js
+++ b/src/generators/TypescriptInterfaceGenerator.test.js
@@ -50,11 +50,64 @@ test("Generate a typescript interface", () => {
 
   expect(fs.existsSync(tmpobj.name + "/interfaces/foo.ts")).toBe(true);
 
-  const res = `export interface Foo {
+  const res = `import { FooBar } from "./foobar";
+
+export interface Foo {
   '@id'?: string;
   id: string;
   foo: any;
   foobar?: FooBar;
+  readonly bar: string;
+}
+`;
+  expect(
+    fs.readFileSync(tmpobj.name + "/interfaces/foo.ts").toString()
+  ).toEqual(res);
+
+  tmpobj.removeCallback();
+});
+
+test("Generate a typescript interface without references to other interfaces", () => {
+  const generator = new TypescriptInterfaceGenerator({
+    templateDirectory: `${__dirname}/../../templates`
+  });
+  const tmpobj = tmp.dirSync({ unsafeCleanup: true });
+
+  const resource = new Resource("abc", "http://example.com/foos", {
+    id: "foo",
+    title: "Foo",
+    readableFields: [
+      new Field("bar", {
+        id: "http://schema.org/url",
+        range: "http://www.w3.org/2001/XMLSchema#string",
+        reference: null,
+        required: true,
+        description: "An URL"
+      })
+    ],
+    writableFields: [
+      new Field("foo", {
+        id: "http://schema.org/url",
+        range: "http://www.w3.org/2001/XMLSchema#datetime",
+        reference: null,
+        required: true,
+        description: "An URL"
+      })
+    ]
+  });
+  const api = new Api("http://example.com", {
+    entrypoint: "http://example.com:8080",
+    title: "My API",
+    resources: [resource]
+  });
+  generator.generate(api, resource, tmpobj.name);
+
+  expect(fs.existsSync(tmpobj.name + "/interfaces/foo.ts")).toBe(true);
+
+  const res = `export interface Foo {
+  '@id'?: string;
+  id: string;
+  foo: any;
   readonly bar: string;
 }
 `;

--- a/templates/typescript/interface.ts
+++ b/templates/typescript/interface.ts
@@ -1,3 +1,9 @@
+{{#each imports}}
+import { {{type}} } from "{{file}}";
+{{/each}}
+{{#if imports.length}}
+
+{{/if}}
 export interface {{{name}}} {
   '@id'?: string;
   id: string;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

I've noticed that the generated interfaces for typescript are missing the `import { ResourceName } from "./resourcefile";` statements, making them less useful when used in a Typescript application (imports would need to be manually added everytime).

This PR fixes this and also adds a test to the typescript generator, testing for both interfaces with references to other interfaces and interfaces without references.


