### PR TITLE
Make id field optional in typescript interface

### DIFF
--- a/src/generators/TypescriptInterfaceGenerator.test.js
+++ b/src/generators/TypescriptInterfaceGenerator.test.js
@@ -54,7 +54,7 @@ test("Generate a typescript interface", () => {
 
 export interface Foo {
   '@id'?: string;
-  id: string;
+  id?: string;
   foo: any;
   foobar?: FooBar;
   readonly bar: string;
@@ -106,7 +106,7 @@ test("Generate a typescript interface without references to other interfaces", (
 
   const res = `export interface Foo {
   '@id'?: string;
-  id: string;
+  id?: string;
   foo: any;
   readonly bar: string;
 }

--- a/templates/typescript/interface.ts
+++ b/templates/typescript/interface.ts
@@ -6,7 +6,7 @@ import { {{type}} } from "{{file}}";
 {{/if}}
 export interface {{{name}}} {
   '@id'?: string;
-  id: string;
+  id?: string;
 {{#each fields}}
  {{#if readonly}} readonly{{/if}} {{{name}}}{{#if notrequired}}?{{/if}}: {{{type}}};
 {{/each}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (i guess)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

As dicussed in https://github.com/api-platform/client-generator/pull/116
By making the id field non required the interface can be used also for POST operations etc