### PR TITLE
Add typescript to the generator interface list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ program
   )
   .option(
     "-g, --generator [generator]",
-    'The generator to use, one of "react", "react-native", "vue", "admin-on-rest"',
+    'The generator to use, one of "react", "react-native", "vue", "admin-on-rest", "typescript"',
     "react"
   )
   .option(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Simple PR to add the typescript generator to the list of the available generators in the CLI help string.
