### PR TITLE
Typescript generator: Handle resources with explicit id field

### DIFF
--- a/src/generators/TypescriptInterfaceGenerator.js
+++ b/src/generators/TypescriptInterfaceGenerator.js
@@ -85,6 +85,17 @@ export default class TypescriptInterfaceGenerator extends BaseGenerator {
       };
     }
 
+    // If id is not present, add it manually with default values
+    if (!("id" in fields)) {
+      fields["id"] = {
+        notrequired: true,
+        name: "id",
+        type: "string",
+        description: null,
+        readonly: false
+      };
+    }
+
     // Parse fields to add relevant imports, required for Typescript
     const fieldsArray = Object.keys(fields).map(e => fields[e]);
     const imports = {};

--- a/src/generators/TypescriptInterfaceGenerator.test.js
+++ b/src/generators/TypescriptInterfaceGenerator.test.js
@@ -54,10 +54,10 @@ test("Generate a typescript interface", () => {
 
 export interface Foo {
   '@id'?: string;
-  id?: string;
   foo: any;
   foobar?: FooBar;
   readonly bar: string;
+  id?: string;
 }
 `;
   expect(
@@ -106,9 +106,67 @@ test("Generate a typescript interface without references to other interfaces", (
 
   const res = `export interface Foo {
   '@id'?: string;
-  id?: string;
   foo: any;
   readonly bar: string;
+  id?: string;
+}
+`;
+  expect(
+    fs.readFileSync(tmpobj.name + "/interfaces/foo.ts").toString()
+  ).toEqual(res);
+
+  tmpobj.removeCallback();
+});
+
+test("Generate a typescript interface with an explicit id field in the readableFields", () => {
+  const generator = new TypescriptInterfaceGenerator({
+    templateDirectory: `${__dirname}/../../templates`
+  });
+  const tmpobj = tmp.dirSync({ unsafeCleanup: true });
+
+  const resource = new Resource("abc", "http://example.com/foos", {
+    id: "foo",
+    title: "Foo",
+    readableFields: [
+      new Field("bar", {
+        id: "http://schema.org/url",
+        range: "http://www.w3.org/2001/XMLSchema#string",
+        reference: null,
+        required: true,
+        description: "An URL"
+      }),
+      new Field("id", {
+        id: "http://schema.org/url",
+        range: "http://www.w3.org/2001/XMLSchema#string",
+        reference: null,
+        required: false,
+        description: "Id"
+      })
+    ],
+    writableFields: [
+      new Field("foo", {
+        id: "http://schema.org/url",
+        range: "http://www.w3.org/2001/XMLSchema#datetime",
+        reference: null,
+        required: true,
+        description: "An URL"
+      })
+    ]
+  });
+  const api = new Api("http://example.com", {
+    entrypoint: "http://example.com:8080",
+    title: "My API",
+    resources: [resource]
+  });
+  generator.generate(api, resource, tmpobj.name);
+
+  expect(fs.existsSync(tmpobj.name + "/interfaces/foo.ts")).toBe(true);
+
+  const res = `export interface Foo {
+  '@id'?: string;
+  foo: any;
+  readonly bar: string;
+  readonly id?: string;
 }
 `;
   expect(

--- a/templates/typescript/interface.ts
+++ b/templates/typescript/interface.ts
@@ -6,7 +6,6 @@ import { {{type}} } from "{{file}}";
 {{/if}}
 export interface {{{name}}} {
   '@id'?: string;
-  id?: string;
 {{#each fields}}
  {{#if readonly}} readonly{{/if}} {{{name}}}{{#if notrequired}}?{{/if}}: {{{type}}};
 {{/each}}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If any of our resources are identified using Doctrine's Identity Through Foreign Entities (https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/composite-primary-keys.html#identity-through-foreign-entities) and they also declare a getter function to serialize their id in the id property of the response, then the standard template defined for the typescript interface does not work for them since it creates 2 members named `id` in the interface. This PR fixes it by removing `id` as a hard-coded field in the Handlebars template and by appending the id field to the list of fields to generate only if no property named id exists.

Code example:

Entity.php

```PHP
/**
 * @ApiResource(
 *     normalizationContext={"groups"={"entityRead"}}
 * )
 * @ORM\Entity(repositoryClass="App\Repository\ProducerRepository")
 * @ORM\HasLifecycleCallbacks()
 */
class Entity
{
    /**
     * @ORM\Id()
     * @ORM\JoinColumn(name="id")
     * @ORM\OneToOne(targetEntity="App\Entity\AppUser", inversedBy="entity", cascade={"persist", "remove"})
     * @Groups({"entityRead","userRead"})
     * @var AppUser
     */
    private $user;
    
    /**
     * @return string|null
     * @Groups({"entityRead","userRead"})
     */
    public function getId(): ?string
    {
        return $this->user->getId();
    }

}
```

When this get serialized by the serializer, we get
```Javascript
{
  user: <user object serialized or IRI>,
  id: '<identifier>'
}
```

Without the `getId()` getter we would only have the `user` property in the response.

However, by adding this getId, I noticed that Api platform would add a new `id` field in the Hydra documentation (standard resources that have a true `id` property do not expose an `id` field in the documentation, I don't know why though), and this would in turn cause the client generator to generate an interface such as (imports omitted for brevity)

```Typescript
interface Entity {
  '@id'?: string;
  'id'?: string;
  'user': User;
  readonly 'id'?: string;
}
```

This makes the typescript compiler not happy as we have a re-definition of the `id` field.

So, maybe this could be solved on the PHP side by always specifying the `id` field in the documentation, but for the time being this solves the issue by selectively adding the `id` field only when it's not already declared on the resource.
