### PR TITLE
Allow to specify http Basic auth credentials for hydra endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     'es6': true,
     'jest': true,
     'node': true,
+    'browser': true
   },
   'parser': 'babel-eslint',
   'parserOptions': {

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ program
     "The hydra prefix used by the API",
     "hydra:"
   )
+  .option("--username [username]", "Username for basic auth (Hydra only)")
+  .option("--password [password]", "Password for basic auth (Hydra only)")
   .option(
     "-g, --generator [generator]",
     'The generator to use, one of "react", "react-native", "vue", "admin-on-rest", "typescript", "next"',
@@ -67,13 +69,21 @@ const resourceToGenerate = program.resource
 const serverPath = program.serverPath ? program.serverPath.toLowerCase() : null;
 
 const parser = entrypointWithSlash => {
+  const options = {};
+  if (program.username && program.password) {
+    const encoded = Buffer.from(
+      `${program.username}:${program.password}`
+    ).toString("base64");
+    options.headers = new Headers();
+    options.headers.set("Authorization", `Basic ${encoded}`);
+  }
   switch (program.format) {
     case "swagger":
       return parseSwaggerDocumentation(entrypointWithSlash);
     case "openapi3":
       return parseOpenApi3Documentation(entrypointWithSlash);
     default:
-      return parseHydraDocumentation(entrypointWithSlash);
+      return parseHydraDocumentation(entrypointWithSlash, options);
   }
 };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | None (at the moment)

Hi all, today I ran across the need for generating code from an endpoint protected with HTTP Basic Auth. Thus, I've modified the main index.js to allow specifing Basic auth credentials from the command line. Unfortunately, I saw that only the hydra parser accepted an `options` parameter, so I was able to add it there only. 

In order to allow the `new Headers()` call, I also had to edit ESLint settings to allow for the browser env. I'm not sure if this is ok for you or not, so let me know if there's another way to do it.

If this is the way to go, I think I might be able to adapt api-doc-parser to enable an options argument for the other 2 formats as well.

`yarn test` output:
```
┌─[±][hydra-basic-auth → origin ✓][client-generator][]
└─▪ yarn test
yarn run v1.19.0
$ jest
 PASS  lib/generators/TypescriptInterfaceGenerator.test.js
 PASS  lib/generators/NextGenerator.test.js
 PASS  lib/generators/VueGenerator.test.js
 PASS  src/generators/TypescriptInterfaceGenerator.test.js
 PASS  lib/generators/QuasarGenerator.test.js
 PASS  src/generators/VueGenerator.test.js
 PASS  src/generators/QuasarGenerator.test.js
 PASS  lib/generators/ReactNativeGenerator.test.js
 PASS  lib/generators/ReactGenerator.test.js
 PASS  lib/generators/AdminOnRestGenerator.test.js
 PASS  src/generators/ReactGenerator.test.js
 PASS  src/generators/ReactNativeGenerator.test.js
 PASS  src/generators/NextGenerator.test.js
 PASS  src/generators/AdminOnRestGenerator.test.js

Test Suites: 14 passed, 14 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        3.858s
Ran all test suites.
Done in 4.78s.
```
