### PR TITLE
Add reset list

### DIFF
--- a/templates/vue-common/mixins/ListMixin.js
+++ b/templates/vue-common/mixins/ListMixin.js
@@ -44,6 +44,8 @@ export default {
       if (!isEmpty(sortBy)) {
         params[`order[${sortBy}]`] = descending ? 'desc' : 'asc';
       }
+      
+      this.resetList = true;
 
       this.getPage(params).then(() => {
         this.options.sortBy = sortBy;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

When sorting or changing a page using Vuetify, the list is not updated. Calling this.resetList fixes the problem.
 