### PR TITLE
Don't always output id in typescript interface

### DIFF
--- a/src/generators/TypescriptInterfaceGenerator.js
+++ b/src/generators/TypescriptInterfaceGenerator.js
@@ -63,17 +63,6 @@ export default class TypescriptInterfaceGenerator extends BaseGenerator {
       };
     }
 
-    // If id is not present, add it manually with default values
-    if (!("id" in fields)) {
-      fields["id"] = {
-        notrequired: true,
-        name: "id",
-        type: "string",
-        description: null,
-        readonly: false
-      };
-    }
-
     // Parse fields to add relevant imports, required for Typescript
     const fieldsArray = Object.keys(fields).map(e => fields[e]);
     const imports = {};

--- a/src/generators/TypescriptInterfaceGenerator.test.js
+++ b/src/generators/TypescriptInterfaceGenerator.test.js
@@ -53,7 +53,6 @@ test("Generate a typescript interface", () => {
   foo: any;
   foobar?: string[];
   readonly bar: string;
-  id?: string;
 }
 `;
   expect(
@@ -104,7 +103,6 @@ test("Generate a typescript interface without references to other interfaces", (
   '@id'?: string;
   foo: any;
   readonly bar: string;
-  id?: string;
 }
 `;
   expect(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | no
| BC breaks?    | yes (as far as "generators" go)
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Hi!

With typescript interfaces, an `id` property is *always* output, even if the API has no id field. Is this on purpose? It was added originally when the typescript interfaces were added (then modified  in #132). Is there a reason `id` should always be included?

Cheers!