### PR TITLE
fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tmp": "^0.1.0"
   },
   "dependencies": {
-    "@api-platform/api-doc-parser": "^0.8.0",
+    "@api-platform/api-doc-parser": "^0.8.3",
     "@babel/runtime": "^7.0.0",
     "chalk": "^2.4.1",
     "commander": "^3.0.1",

--- a/templates/react/components/foo/Form.js
+++ b/templates/react/components/foo/Form.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Field, reduxForm } from 'redux-form';
+import { reduxForm } from 'redux-form';
 import PropTypes from 'prop-types';
 
 class Form extends Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@api-platform/api-doc-parser@^0.8.0":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@api-platform/api-doc-parser/-/api-doc-parser-0.8.2.tgz#4a8edae414650b26f3ddd8acf42a201522523a14"
-  integrity sha512-TUa6MMcvzouC5wjGn72fky1GBC0gu1hVRqKqooV2HUuOCmn5oQb6TAbVhyuDZjRPvmkB3I3pZwIkLxSo4t6UBw==
+"@api-platform/api-doc-parser@^0.8.3":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@api-platform/api-doc-parser/-/api-doc-parser-0.8.4.tgz#9804c8acd4ace037966532df9e4fb18eeb28db82"
+  integrity sha512-ExzX+1H/30JGaLgJ1EkTb7yQOJXCtamE05rdfrbL53MlnJvKNU59ti0xETZWUy/eDkIX1KCOwMZSOTJa4DYv5g==
   dependencies:
     jsonld "^1.5.0"
     lodash.get "^4.4.2"


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #...
| License       | MIT
| Doc PR        | 

After some investigation, I realised that code block for fields are not generated in the `Form.js` again. The API Platform hydra doc changed the `writableFields` and it is always empty after some debugging. It seems that not only react generator is impacted.

Updating the `api-doc-parser` fixed the issue, I don't upgrade to the latest version because I can't be sure of the different impact for other generators. We could make another MR to upgrade to the latest version later.