### PR TITLE
ci: use Yarn instead of NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
-name: Deploy to NPM
+name: Release
 
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
+
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,8 +14,8 @@ jobs:
       with:
         node-version: '15'
         registry-url: 'https://registry.npmjs.org'
-    - run: npm install
-    - run: npm build
+    - run: yarn install
+    - run: yarn build
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Fix #275
| License       | MIT
| Doc PR        | n/a

Switch to Yarn (the current script call to build is faulty, it should be `npm run build`). Using Yarn allows leveraging `yarn.lock`.