### PR TITLE
feat: Normalize nested objects

### DIFF
--- a/templates/react-common/utils/dataAccess.js
+++ b/templates/react-common/utils/dataAccess.js
@@ -65,7 +65,7 @@ export function normalize(data) {
   // Flatten nested documents
   return mapValues(data, value =>
     Array.isArray(value)
-      ? value.map(v => get(v, '@id', v))
+      ? value.map(v => normalize(v))
       : value instanceof Object ? normalize(value)
       : get(value, '@id', value)
   );

--- a/templates/react-common/utils/dataAccess.js
+++ b/templates/react-common/utils/dataAccess.js
@@ -66,6 +66,7 @@ export function normalize(data) {
   return mapValues(data, value =>
     Array.isArray(value)
       ? value.map(v => get(v, '@id', v))
+      : value instanceof Object ? normalize(value)
       : get(value, '@id', value)
   );
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT
| Doc PR        | api-platform/docs

When using normalization groups to expose some properties of a nested object, the current code only retrieves the IRI. It seems interesting to be able to normalize the nested item if it is an object, and return the real object instead of a string IRI.