### PR TITLE
feat: upgrade to commander.js v8 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@api-platform/api-doc-parser": "^0.12.0",
     "@babel/runtime": "^7.0.0",
     "chalk": "^4.1.0",
-    "commander": "^6.2.1",
+    "commander": "^8.2.0",
     "handlebars": "^4.0.12",
     "handlebars-helpers": "^0.10.0",
     "isomorphic-fetch": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ if (
   program.help();
 }
 
+const options = program.opts();
+
 const entrypoint =
   program.args[0] || process.env.API_PLATFORM_CLIENT_GENERATOR_ENTRYPOINT;
 const outputDirectory =
@@ -64,29 +66,29 @@ const entrypointWithSlash = entrypoint.endsWith("/")
   ? entrypoint
   : entrypoint + "/";
 
-const generator = generators(program.generator)({
-  hydraPrefix: program.hydraPrefix,
-  templateDirectory: program.templateDirectory,
+const generator = generators(options.generator)({
+  hydraPrefix: options.hydraPrefix,
+  templateDirectory: options.templateDirectory,
 });
-const resourceToGenerate = program.resource
-  ? program.resource.toLowerCase()
+const resourceToGenerate = options.resource
+  ? options.resource.toLowerCase()
   : null;
-const serverPath = program.serverPath ? program.serverPath.toLowerCase() : null;
+const serverPath = options.serverPath ? options.serverPath.toLowerCase() : null;
 
 const parser = (entrypointWithSlash) => {
   const options = {};
-  if (program.username && program.password) {
+  if (options.username && options.password) {
     const encoded = Buffer.from(
-      `${program.username}:${program.password}`
+      `${options.username}:${options.password}`
     ).toString("base64");
     options.headers = new Headers();
     options.headers.set("Authorization", `Basic ${encoded}`);
   }
-  if (program.bearer) {
+  if (options.bearer) {
     options.headers = new Headers();
-    options.headers.set("Authorization", `Bearer ${program.bearer}`);
+    options.headers.set("Authorization", `Bearer ${options.bearer}`);
   }
-  switch (program.format) {
+  switch (options.format) {
     case "swagger": // deprecated
     case "openapi2":
       return parseSwaggerDocumentation(entrypointWithSlash);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,10 +2102,15 @@ commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^6.2.0, commander@^6.2.1:
+commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.2.0.tgz#37fe2bde301d87d47a53adeff8b5915db1381ca8"
+  integrity sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==
 
 compare-versions@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | #257 
| License       | MIT
| Doc PR        | 

With [commander.js v7](https://github.com/tj/commander.js/blob/master/CHANGELOG.md#700-2021-01-15), `options` are stored in another object instead of directly in `program`. Rest is working as intended.
