### PR TITLE
fix: don't ignore login data set via CLI params (regression from #316)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,20 +79,19 @@ async function main() {
     : null;
 
   const parser = (entrypointWithSlash) => {
+    // parserOptions are used to set headers on the hydra-requests
     const parserOptions = {};
-    if (parserOptions.username && parserOptions.password) {
+    // options refers to the opts set via the CLI
+    if (options.username && options.password) {
       const encoded = Buffer.from(
-        `${parserOptions.username}:${parserOptions.password}`
+        `${options.username}:${options.password}`
       ).toString("base64");
       parserOptions.headers = new Headers();
       parserOptions.headers.set("Authorization", `Basic ${encoded}`);
     }
-    if (parserOptions.bearer) {
+    if (options.bearer) {
       parserOptions.headers = new Headers();
-      parserOptions.headers.set(
-        "Authorization",
-        `Bearer ${parserOptions.bearer}`
-      );
+      parserOptions.headers.set("Authorization", `Bearer ${options.bearer}`);
     }
     switch (options.format) {
       case "swagger": // deprecated


### PR DESCRIPTION
In attempting to fix an empty `options` object overshadowing the options set by the user via CLI, #316 mistakenly adjusted `options.username`, `options.password` and `options.bearer` to be attributes of the newly introduced `parserOptions`. They should, however, still refer to the `options` object that holds all the information previously set via CLI arguments.

I also added two comments to make the difference between the two sets of options more clear.

| Q             | A
| ------------- | ---
| Branch?       | current stable version branch for bug fixes <!-- see below -->
| Tickets       | n.a. <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | n.a. <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
